### PR TITLE
Add Hash URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ if (parsedURL.query.gist) {
   var gistID = parsedURL.query.gist
   enableShare(gistID)
 }
+else if (parsedURL.hash){
+  var gistID = parsedURL.hash.replace("#", "")
+  enableShare(gistID)
+}
 
 var loadingClass = elementClass(document.querySelector('.loading'))
 var outputEl = document.querySelector('#play')


### PR DESCRIPTION
This should fix #7.

After checking for `?gist=` the scripts checks whether a location hash is given (A query is preferred because it's less likely to contain some kind of url junk) and if so calls the `enableShare()`-function.
