### PR TITLE
Show helpful errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,8 @@ loadCode(function(err, code) {
   sandbox.on('bundleEnd', function(bundle) {
     crosshairClass.remove('spinning')
     crosshair.style.display = 'none'
+    if (!bundle)
+      tooltipMessage('error', 'There was an issue loading the modules')
   })
   
   sandbox.on('modules', function(modules) {
@@ -263,3 +265,31 @@ loadCode(function(err, code) {
     })
   }
 })
+
+/*
+  display error/warning messages in the site header
+  cssClass should be a default bootstrap class
+  .warning .alert .info .success
+  text is the message content
+*/
+function tooltipMessage(cssClass, text) {
+  var message = document.querySelector('.alert')
+  if (message) {
+    message.classList.remove('hidden')
+    message.classList.add('alert-'+cssClass)
+    message.innerHTML = text
+  } else {
+    message = document.createElement('div')
+    message.classList.add('alert')
+    var close = document.createElement('span')
+    close.classList.add('pull-right')
+    close.innerHTML = '&times;'
+    close.addEventListener('click', function () {
+      this.parentNode.classList.add('hidden')
+    }, false)
+    message.classList.add('alert-'+cssClass)
+    message.innerHTML = text
+    document.querySelector('body').appendChild(message)
+    message.appendChild(close)
+  }
+}

--- a/style.css
+++ b/style.css
@@ -152,3 +152,11 @@ body > pre { display: none }
 	-webkit-animation-duration:.5s;
 	-webkit-animation-delay:.1s;
 }
+
+.alert {
+  width:400px;
+  position:absolute;
+  top:5px;
+  left:50%;
+  margin-left:-200px;
+}


### PR DESCRIPTION
I've added a function that creates a tooltip based of the default bootstrap styles. You pass it a class name like alert, warning etc and a message for different types of message errors. Hopefully it is flexible enough so that it can be used in other places in the application.

From what I've seen the sandbox module emits a 'bundleEnd' event and returns the error so I'm not sure how to capture the err and response from the `request` call. Would it be more useful to emit a bundleError with the response and include that in the error message ?
