### PR TITLE
Modules in use now shows only valid modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,8 +206,8 @@ function initialize() {
       packageTags.html('')
       var modules = detective(editor.editor.getValue())
       modules.map(function(module) {
-        $.getJSON('http://jsonp.jit.su/?callback=?&url=http://isaacs.iriscouch.com/registry/' + module, function(found){
-            if(found){
+        request('http://cors.maxogden.com/http://isaacs.iriscouch.com/registry/' + module, function(err, resp){            
+          if(resp.statusCode != 404){
               var tag =
                 '<span class="tag"><a target="_blank" href="http://npmjs.org/' +
                   module + '"><span>' + module + '&nbsp;&nbsp;</span></a></span>'


### PR DESCRIPTION
Potential fix for #41 

@maxogden Tried using `jsonp` module, but that is failing saying it can't find the script tag!

So had to use this work around, now the 'modules in use' section lists only those modules that are present in npm registry.

It would be better if we highlight those which are invalid?

Sample Output:
![screen shot 2014-03-23 at 14 11 06](https://f.cloud.github.com/assets/18315/2492915/093b05bc-b267-11e3-8f6e-908ef22f5bf4.png)
