### PR TITLE
Migrate index.html example to raf@1.0.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ document.body.appendChild(canvas)
 var context = canvas.getContext("2d")
 var zoom = 10
 
-requestAnimationFrame(canvas, function onFrame(delta) {
+requestAnimationFrame(function onFrame(delta) {
   zoom += delta * 0.025
   
   context.clearRect (0, 0, 500, 500)
@@ -103,6 +103,8 @@ requestAnimationFrame(canvas, function onFrame(delta) {
   context.lineWidth = 5
   context.strokeStyle = '#003300'
   context.stroke()
+
+  requestAnimationFrame(onFrame);
 })
 </script>
   <script type="text/javascript" src="flatui-deps.js"></script>


### PR DESCRIPTION
`raf` was split in two (`raf` and `raf-stream`) before the 1.0.0 release. `raf` is now the actual polyfill, while `raf-stream` is an event emitter which wraps `raf`.

I don't know how the browserify-cdn caching works, but I'm still receiving raf@0.1.3 even after clearing my local IndexDB. Once browserify-cdn starts delivering 1.0.0 the example in `index.html` will stop working (without this fix). The deployment of this fix needs to somehow coincide with the cache expiration of `raf`.

Another solution to this problem (which would sidestep the challenges outlined above) would be to use `raf-stream` instead of `raf`. It's your call, I'm happy to do either (although I do think `raf-stream` is slightly overkill for this example).
