### PR TITLE
Handle Gist URLs for past commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,9 +372,10 @@ function getGistID(parsedURL) {
   if (!gistID) return
   if (gistID.indexOf('/') > -1) {
     var parts = gistID.split('/')
+    var user = parts.shift()
     gistID = {
-      user: parts[0],
-      id: parts[1]
+      user: user,
+      id: parts.join('/')
     }
   } else {
     gistID = {


### PR DESCRIPTION
Past commits are represented as {original_id}/{version}

Here's a past commit of a gist I had tried in RequireBin:
https://gist.github.com/BigBlueHat/f47e6cfda27afccc03be/c02328cde004eda920a8c39a36858b2add7f702d

I attempted: [`?gist=f47e6cfda27afccc03be/c02328cde004eda920a8c39a36858b2add7f702d`](http://requirebin.com/?gist=f47e6cfda27afccc03be/c02328cde004eda920a8c39a36858b2add7f702d) which threw this error:

```
{"error":"no index.js in this gist","json":{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}}
```

...because it was treating the first part (`f47e6cfda27afccc03be`) as the user.

Adding the user to the mix: [`?gist=BigBlueHat/f47e6cfda27afccc03be/c02328cde004eda920a8c39a36858b2add7f702d`](http://requirebin.com/?gist=BigBlueHat/f47e6cfda27afccc03be/c02328cde004eda920a8c39a36858b2add7f702d) results in the latest version of the Gist being returned--not the requested past commit.

This patch should handle both cases--despite the `user` variable not always being a username (re-name it if you must :wink: ).
