### PR TITLE
Deploying no longer dependes on changing the content of the branch gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/config.js
+++ b/config.js
@@ -1,15 +1,16 @@
 // for production:
 
-// module.exports = {
-//   GITHUB_CLIENT: 'f7b1530b019cbb2619d5',
-//   GATEKEEPER: 'http://gatekeeper.maxogden.com',
-//   BROWSERIFYCDN: 'https://wzrd.in'
-// }
-
-// for local dev:
-
-module.exports = {
-  GITHUB_CLIENT: '77ca0223691ae7245419', // redirect goes to localhost:5000
-  GATEKEEPER: 'http://localhost:9999',
-  BROWSERIFYCDN: 'https://wzrd.in'
+var envs = {
+  production: {
+   GITHUB_CLIENT: 'f7b1530b019cbb2619d5',
+   GATEKEEPER: 'http://gatekeeper.maxogden.com',
+   BROWSERIFYCDN: 'https://wzrd.in'
+  },
+  dev: {
+    GITHUB_CLIENT: '77ca0223691ae7245419', // redirect goes to localhost:5000
+      GATEKEEPER: 'http://localhost:9999',
+    BROWSERIFYCDN: 'https://wzrd.in'
+  }
 }
+
+module.exports = envs.dev

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "beefy embed.js:embed-bundle.js index.js:bundle.js -p 5000",
     "build": "browserify embed.js -o embed-bundle.js && browserify index.js -o bundle.js --debug",
     "minify": "cat bundle.js | uglifyjs -o bundle.js",
+    "modifyconfig": "sed -i '.bak' 's/envs.dev/envs.production/' config.js && rm config.js.bak",
     "deploy": "standard && gh-pages-deploy",
     "test": "standard"
   },
@@ -13,7 +14,8 @@
     "cname": "requirebin.com",
     "prep": [
       "build",
-      "minify"
+      "minify",
+      "modifyconfig"
     ],
     "noprompt": false
   },


### PR DESCRIPTION
A common issue I've seen is that the file `config.js` of `master` is used in `gh-pages`, however `gh-pages` should have a 'production' version of the file, now the contents of the file `config.js` are modified only when `npm run deploy` is run, text substitution is done with `sed`

This doesn't have an impact on the app but on the build process which I've verified on the fork