### PR TITLE
Alternative embed version

### DIFF
--- a/css/embed.css
+++ b/css/embed.css
@@ -14,6 +14,7 @@ iframe {
 }
 body {
   font: 300 12px "Helvetica Neue", Helvetica, Arial;
+  overflow: hidden;
 }
 pre {
   padding: 10px;
@@ -28,6 +29,7 @@ code {
 
 /* top bar */
 #nav {
+  z-index: 1;
   padding: 10px;
   height: 30px;
   border-bottom: 1px solid #eee;
@@ -53,13 +55,22 @@ code {
 }
 
 /* editors */
+#output {
+  position: absolute;
+  top: 50px;
+  overflow: auto;
+}
 #output > div {
   display: none;
 }
 #output > div.active {
   display: block;
 }
-#output {
-  position: absolute;
-  top: 50px;
+
+/* plain mode */
+body.plain #output {
+  top: 0;
+}
+body.plain #nav {
+  display: none;
 }

--- a/css/embed.css
+++ b/css/embed.css
@@ -29,6 +29,7 @@ code {
 
 /* top bar */
 #nav {
+  display: none;
   z-index: 1;
   padding: 10px;
   height: 30px;
@@ -54,6 +55,27 @@ code {
   width: 150px;
 }
 
+/* badge */
+#requirebin-badge {
+  position: absolute;
+  display: none;
+  top: -75px;
+  right: -75px;
+  width: 100px;
+  height: 100px;
+  z-index: 1;
+
+  -webkit-transition: all 500ms ease;
+  -moz-transition: all 500ms ease;
+  -ms-transition: all 500ms ease;
+  -o-transition: all 500ms ease;
+  transition: all 500ms ease;
+}
+#requirebin-badge:hover {
+  top: -15px;
+  right: -15px;
+}
+
 /* editors */
 #output {
   position: absolute;
@@ -68,9 +90,12 @@ code {
 }
 
 /* plain mode */
-body.plain #output {
+.plain #output {
   top: 0;
 }
-body.plain #nav {
+.plain #nav {
   display: none;
+}
+.plain #requirebin-badge {
+  display: block;
 }

--- a/css/embed.css
+++ b/css/embed.css
@@ -1,0 +1,65 @@
+/* utils */
+html, body {
+  height: 100%;
+}
+.stretch {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+iframe {
+  position: absolute;
+}
+body {
+  font: 300 12px "Helvetica Neue", Helvetica, Arial;
+}
+pre {
+  padding: 10px;
+  margin: 0;
+  border: none;
+  background-color: transparent;
+}
+code {
+  line-height: 14px;
+  font-size: 10px;
+}
+
+/* top bar */
+#nav {
+  padding: 10px;
+  height: 30px;
+  border-bottom: 1px solid #eee;
+}
+#nav .btn {
+  display: none;
+  font-size: 12px;
+  padding: 5px 7px;
+}
+#nav .btn.visible {
+  display: inline-block;
+}
+.logo {
+  position: absolute;
+  right: 5px;
+  top: 10px;
+}
+.logo a {
+  text-decoration: none;
+}
+.logo img {
+  width: 150px;
+}
+
+/* editors */
+#output > div {
+  display: none;
+}
+#output > div.active {
+  display: block;
+}
+#output {
+  position: absolute;
+  top: 50px;
+}

--- a/embed2.html
+++ b/embed2.html
@@ -19,9 +19,15 @@
       </div>
 
       <div class="logo">
-        <a id="requirebin-link" href="/" target="_blank">Edit on <img src="img/logo-black.png"></a>
+        <a class="requirebin-link" href="/" target="_blank">
+          Edit on <img src="img/logo-black.png">
+        </a>
       </div>
     </div>
+
+    <a class="requirebin-link" target="_blank">
+      <img id="requirebin-badge" src="badge.png" alt="edit on requirebin"/>
+    </a>
 
     <div id="output" class="stretch">
       <div id="result" class="active"></div>

--- a/embed2.html
+++ b/embed2.html
@@ -40,6 +40,6 @@
     </div>
 
     <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
-    <script type='text/javascript' src="embed-bundle.js"></script>
+    <script type='text/javascript' src="embed-bundle-v2.js"></script>
   </body>
 </html>

--- a/embed2.html
+++ b/embed2.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css"/>
+    <link rel="stylesheet" href="css/bootstrap.css"/>
+    <link rel="stylesheet" href="flatui/css/flat-ui.css"/>
+    <link rel="stylesheet" href="css/embed.css"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/vs.min.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="nav" class="stretch">
+      <div id="links" class="btn-group">
+        <a class="btn btn-primary" id="result-link" href="#result">result</a>
+        <a class="btn" id="code-link" href="#code">code</a>
+        <a class="btn" id="head-link" href="#head">&lt;head&gt;</a>
+        <a class="btn" id="body-link" href="#body">&lt;body&gt;</a>
+        <a class="btn" id="meta-link" href="#meta">package.json</a>
+      </div>
+
+      <div class="logo">
+        <a id="requirebin-link" href="/" target="_blank">Edit on <img src="img/logo-black.png"></a>
+      </div>
+    </div>
+
+    <div id="output" class="stretch">
+      <div id="result" class="active"></div>
+      <div id="code">
+        <pre><code class="js"></code></pre>
+      </div>
+      <div id="head">
+        <pre><code class="html"></code></pre>
+      </div>
+      <div id="body">
+        <pre><code class="html"></code></pre>
+      </div>
+      <div id="meta">
+        <pre><code class="json"></code></pre>
+      </div>
+    </div>
+
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+    <script type='text/javascript' src="embed-bundle.js"></script>
+  </body>
+</html>

--- a/embed2.js
+++ b/embed2.js
@@ -22,22 +22,21 @@ function run () {
 }
 
 function updateUIBeforeGistLoad () {
-  // update the link to requirebin
-  document.getElementById('requirebin-link').href = 'http://requirebin.com/' + binURL
+  // update the links to requirebin
+  $('.requirebin-link').attr('href', 'http://requirebin.com/' + binURL)
 
-  // disable some tabs
+  // tabs state
   var tabs = (parsedURL.query.tabs || '')
     .split(',')
-    .filter(function (tok) { return !!tok })
+    .filter(Boolean)
   if (tabs.length) {
     $('#result-link').addClass('visible')
-  }
-  tabs.forEach(function (tab) {
-    $('#' + tab + '-link').addClass('visible')
-  })
-
-  // if no tab is enabled then plain mode is activated
-  if (!tabs.length) {
+    $('#nav').show()
+    tabs.forEach(function (tab) {
+      $('#' + tab + '-link').addClass('visible')
+    })
+  } else {
+    // if no tab is enabled then plain mode is activated
     $(document.body).addClass('plain')
   }
 }

--- a/embed2.js
+++ b/embed2.js
@@ -3,6 +3,7 @@ var url = require('url')
 var iframe = require('iframe')
 var getGistFiles = require('./get-gist-files')
 var $ = window.jQuery
+var hljs = window.hljs
 var parsedURL = url.parse(window.location.href, true)
 var gistID = parsedURL.query.gist
 
@@ -15,12 +16,12 @@ if (gistID.indexOf('/') > -1) gistID = gistID.split('/')[1]
 
 run()
 
-function run() {
+function run () {
   updateUIBeforeGistLoad()
   loadFromAPI(gistID)
 }
 
-function updateUIBeforeGistLoad() {
+function updateUIBeforeGistLoad () {
   // update the link to requirebin
   document.getElementById('requirebin-link').href = 'http://requirebin.com/' + binURL
 
@@ -67,7 +68,6 @@ function loadFromAPI (gistID) {
 }
 
 function render (content) {
-
   if (!content.bundle || !content.meta) {
     content.bundle = 'document.write("not a valid requirebin gist - missing minified.js")'
   }
@@ -80,16 +80,16 @@ function render (content) {
   })
 }
 
-function updateUI(content) {
+function updateUI (content) {
   // highlight the code
   ['code', 'head', 'body', 'meta'].forEach(function (key) {
     var box = document.querySelector('#' + key + ' code')
     box.textContent = box.innerText = content[key]
   })
-  hljs.initHighlightingOnLoad();
+  hljs.initHighlightingOnLoad()
 }
 
-function setUpUIController(content) {
+function setUpUIController (content) {
   window.onpopstate = function () {
     var hash = location.hash.substr(1)
     if (content[hash] || hash === 'result') {
@@ -98,7 +98,7 @@ function setUpUIController(content) {
   }
 }
 
-function changeEditor(hash) {
+function changeEditor (hash) {
   $codeEls.removeClass('active')
   $links.removeClass('btn-primary')
   $('#' + hash).addClass('active')

--- a/embed2.js
+++ b/embed2.js
@@ -79,7 +79,7 @@ function render (content) {
 
   // disable default styling on the iframe
   if (content.head) {
-    content.head = '<style> html, body{ margin: 0; padding: 0; border: 0; }</style>' + content.head;
+    content.head = '<style> html, body{ margin: 0; padding: 0; border: 0; }</style>' + content.head
   }
 
   iframe({

--- a/embed2.js
+++ b/embed2.js
@@ -1,0 +1,106 @@
+var jsonp = require('jsonp')
+var url = require('url')
+var iframe = require('iframe')
+var getGistFiles = require('./get-gist-files')
+var $ = window.jQuery
+var parsedURL = url.parse(window.location.href, true)
+var gistID = parsedURL.query.gist
+
+var $codeEls = $('#output > div')
+var $links = $('#links a')
+
+var binURL = '/?gist=' + gistID
+
+if (gistID.indexOf('/') > -1) gistID = gistID.split('/')[1]
+
+run()
+
+function run() {
+  updateUIBeforeGistLoad()
+  loadFromAPI(gistID)
+}
+
+function updateUIBeforeGistLoad() {
+  // update the link to requirebin
+  document.getElementById('requirebin-link').href = 'http://requirebin.com/' + binURL
+
+  // disable some tabs
+  var tabs = (typeof parsedURL.query.tabs !== 'undefined'
+    ? parsedURL.query.tabs
+    : 'code,head,body,meta').split(',')
+  // result is always visible
+  $('#result-link').addClass('visible')
+  tabs.forEach(function (tab) {
+    $('#' + tab + '-link').addClass('visible')
+  })
+}
+
+function loadFromAPI (gistID) {
+  jsonp('https://api.github.com/gists/' + gistID, function (err, gist) {
+    if (err) return console.log(err)
+
+    getGistFiles(gist, ['page-head.html', 'page-body.html', 'head.html', 'minified.js', 'package.json', 'index.js'], function (err) {
+      if (err) return console.log(err)
+      var files = gist.data.files
+      var content = {}
+
+      var headFile = files['page-head.html'] || files['head.html']
+      if (headFile) {
+        content.head = headFile.content
+      }
+      if (files['page-body.html']) {
+        content.body = files['page-body.html'].content
+      }
+      if (files['minified.js']) {
+        content.bundle = files['minified.js'].content
+        content.code = files['index.js'].content
+      }
+      if (files['package.json']) {
+        content.meta = files['package.json'].content
+      }
+
+      updateUI(content)
+      setUpUIController(content)
+      render(content)
+    })
+  })
+}
+
+function render (content) {
+
+  if (!content.bundle || !content.meta) {
+    content.bundle = 'document.write("not a valid requirebin gist - missing minified.js")'
+  }
+
+  iframe({
+    container: document.getElementById('result'),
+    head: content.head,
+    body: content.body + '<script type="text/javascript">' +
+    'setTimeout(function(){\n;' + content.bundle + '\n;}, 0)</script>'
+  })
+}
+
+function updateUI(content) {
+  // highlight the code
+  ['code', 'head', 'body', 'meta'].forEach(function (key) {
+    var box = document.querySelector('#' + key + ' code')
+    box.textContent = box.innerText = content[key]
+  })
+  hljs.initHighlightingOnLoad();
+}
+
+function setUpUIController(content) {
+  window.onpopstate = function () {
+    var hash = location.hash.substr(1)
+    if (content[hash] || hash === 'result') {
+      changeEditor(hash)
+    }
+  }
+}
+
+function changeEditor(hash) {
+  $codeEls.removeClass('active')
+  $links.removeClass('btn-primary')
+  $('#' + hash).addClass('active')
+  $('#' + hash + '-link').addClass('btn-primary')
+}

--- a/embed2.js
+++ b/embed2.js
@@ -26,14 +26,20 @@ function updateUIBeforeGistLoad () {
   document.getElementById('requirebin-link').href = 'http://requirebin.com/' + binURL
 
   // disable some tabs
-  var tabs = (typeof parsedURL.query.tabs !== 'undefined'
-    ? parsedURL.query.tabs
-    : 'code,head,body,meta').split(',')
-  // result is always visible
-  $('#result-link').addClass('visible')
+  var tabs = (parsedURL.query.tabs || '')
+    .split(',')
+    .filter(function (tok) { return !!tok })
+  if (tabs.length) {
+    $('#result-link').addClass('visible')
+  }
   tabs.forEach(function (tab) {
     $('#' + tab + '-link').addClass('visible')
   })
+
+  // if no tab is enabled then plain mode is activated
+  if (!tabs.length) {
+    $(document.body).addClass('plain')
+  }
 }
 
 function loadFromAPI (gistID) {
@@ -70,6 +76,11 @@ function loadFromAPI (gistID) {
 function render (content) {
   if (!content.bundle || !content.meta) {
     content.bundle = 'document.write("not a valid requirebin gist - missing minified.js")'
+  }
+
+  // disable default styling on the iframe
+  if (content.head) {
+    content.head = '<style> html, body{ margin: 0; padding: 0; border: 0; }</style>' + content.head;
   }
 
   iframe({

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "element-class": "0.0.2",
     "github-api": "0.7.0",
     "github-oauth": "0.0.4",
+    "iframe": "^0.3.1",
     "javascript-editor": "~0.2.1",
     "jsonp": "0.0.3",
     "keydown": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "create programs in the browser using modules from NPM",
   "scripts": {
     "start": "beefy embed.js:embed-bundle.js index.js:bundle.js -p 5000",
-    "build": "browserify embed.js -o embed-bundle.js && browserify index.js -o bundle.js --debug",
+    "build": "browserify embed.js -o embed-bundle.js && browserify embed2.js -o embed-bundle-v2.js && browserify index.js -o bundle.js --debug",
     "minify": "cat bundle.js | uglifyjs -o bundle.js",
     "modifyconfig": "sed -i '.bak' 's/envs.dev/envs.production/' config.js && rm config.js.bak",
     "deploy": "standard && gh-pages-deploy",


### PR DESCRIPTION
#90. The ui is kinda similar to the one used on the main page, to maintain compatibility with already embedded bins the new ui is accessed through `requirebin.com/embed2?gist=...`, tabs can be hidden using the `tabs` query param which is a comma delimited string with the visible tabs e.g. `code,head,body,meta`

Examples of new embedded urls:

```
// normal
requirebin.com/embed2?gist=maurizzzio/6c3976b49110acdfcbc1
// with all the tabs disabled
requirebin.com/embed2?gist=maurizzzio/6c3976b49110acdfcbc1&tabs=
// with the code tab enabled only
requirebin.com/embed2?gist=maurizzzio/6c3976b49110acdfcbc1&tabs=code
```

There's no way to get an embedv2 link as of now (it's like an easter egg) but it's a good start, what do you suggest guys?

![embed-v2](https://cloud.githubusercontent.com/assets/1616682/6934475/87443f74-d803-11e4-944f-97518a3b7cfc.gif)