### PR TITLE
adhere to padded-blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,6 +337,5 @@ function initialize () {
     setTimeout(function () {
       actions.play()
     }, 500)
-
   })
 }

--- a/lib/github-gist.js
+++ b/lib/github-gist.js
@@ -53,7 +53,6 @@ Gist.prototype.save = function (gist, id, opts, callback) {
           return complete(null, data) // successful fork update
         })
       })
-
     })
   })
 }


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.