### PR TITLE
responsive ui bug fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -261,7 +261,7 @@ body > pre { display: none }
   }
 }
 
-@media only screen and (max-width: 1150px) {
+@media only screen and (max-width: 1255px) {
   .tagline {
     display: none;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,9 @@ a { cursor: pointer; cursor: hand; }
 
 .cacheState { float: right; line-height: 52px; margin-right: 10px; font-size: 11px; }
 
-.actionsMenu { width: 224px; float: right; margin: 5px 10px; }
+.dk_options, .actionsMenu { width: 190px; }
+
+.actionsMenu { float: right; margin: 5px 10px; }
 .actionsButtons { margin: 5px 0; float: right; }
 .actionsButtons i { position: relative; top: 1px; }
 .actionsButtons .fui-new-16 { margin-right: 7px; }

--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,7 @@ a { cursor: pointer; cursor: hand; }
 
 .cacheState { float: right; line-height: 52px; margin-right: 10px; font-size: 11px; }
 
-.dk_options, .actionsMenu { width: 190px; }
+.actionsMenu, .actionsMenu .dk_options { width: 190px; }
 
 .actionsMenu { float: right; margin: 5px 10px; }
 .actionsButtons { margin: 5px 0; float: right; }


### PR DESCRIPTION
This fixes the overflowing-editor-menu bug (#83) by shaving ~35px off the Actions menu + dropdown. I also increased the `max-width` for hiding the tagline which should help prevent the overflow too.

![screen shot 2015-10-08 at 9 27 30 am](https://cloud.githubusercontent.com/assets/2744987/10368123/d8fd92b4-6da1-11e5-8cee-0337cdc60fd6.png)
